### PR TITLE
Older forge versions don't support lenient json.

### DIFF
--- a/app/assets/js/processbuilder.js
+++ b/app/assets/js/processbuilder.js
@@ -505,6 +505,9 @@ class ProcessBuilder {
                     case 'user_type':
                         val = 'mojang'
                         break
+                    case 'user_properties':
+                        val = "{}"
+                        break
                     case 'version_type':
                         val = this.versionData.type
                         break


### PR DESCRIPTION
Running forge 1.8.9 with arg below ends with exception json lenient.
`--userProperties ${user_properties}`
