### PR TITLE
Fix for "Image could not be created error" on macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ function createMenu() {
 function getPlatformIcon(filename){
     const opSys = process.platform
     if (opSys === 'darwin') {
-        filename = filename + '.icns'
+        filename = filename + '.png'
     } else if (opSys === 'win32') {
         filename = filename + '.ico'
     } else {


### PR DESCRIPTION
When attempting to run the app, an error would occur when attemting
to set the browser window platform specific icon. After tweaking to
png, the electron app now launches correctly for macOS 10.15.4