### PR TITLE
Catch invalid JSON parsing in pullLocal and pullRemote + Extra error overlay information

### DIFF
--- a/app/assets/js/distromanager.js
+++ b/app/assets/js/distromanager.js
@@ -548,7 +548,6 @@ exports.pullRemote = function(){
             if(!error){
                 try {
                     data = DistroIndex.fromJSON(JSON.parse(body))
-                    resolve(data)
                 } catch(e) {
                     reject('We cannot parse the JSON in the remote distribution file')
                 }
@@ -574,6 +573,7 @@ exports.pullLocal = function(){
     return new Promise((resolve, reject) => {
         fs.readFile(DEV_MODE ? DEV_PATH : DISTRO_PATH, 'utf-8', (err, d) => {
             if(!err){
+                logger.log(d)
                 try {
                     data = DistroIndex.fromJSON(JSON.parse(d))
                     resolve(data)

--- a/app/assets/js/distromanager.js
+++ b/app/assets/js/distromanager.js
@@ -546,11 +546,11 @@ exports.pullRemote = function(){
         const distroDest = path.join(ConfigManager.getLauncherDirectory(), 'distribution.json')
         request(opts, (error, resp, body) => {
             if(!error){
-                
                 try {
                     data = DistroIndex.fromJSON(JSON.parse(body))
-                } catch (e) {
-                    reject(e)
+                    resolve(data)
+                } catch(e) {
+                    reject('We cannot parse the JSON in the remote distribution file')
                 }
 
                 fs.writeFile(distroDest, body, 'utf-8', (err) => {
@@ -574,8 +574,12 @@ exports.pullLocal = function(){
     return new Promise((resolve, reject) => {
         fs.readFile(DEV_MODE ? DEV_PATH : DISTRO_PATH, 'utf-8', (err, d) => {
             if(!err){
-                data = DistroIndex.fromJSON(JSON.parse(d))
-                resolve(data)
+                try {
+                    data = DistroIndex.fromJSON(JSON.parse(d))
+                    resolve(data)
+                } catch(e) {
+                    reject('We cannot parse the JSON in the local distribution file')
+                }
             } else {
                 reject(err)
             }

--- a/app/assets/js/scripts/uibinder.js
+++ b/app/assets/js/scripts/uibinder.js
@@ -110,14 +110,16 @@ function showFatalStartupError(){
             document.getElementById('overlayContainer').style.background = 'none'
             setOverlayContent(
                 'Fatal Error: Unable to Load Distribution Index',
-                'A connection could not be established to our servers to download the distribution index. No local copies were available to load. <br><br>The distribution index is an essential file which provides the latest server information. The launcher is unable to start without it. Ensure you are connected to the internet and relaunch the application.',
-                'Close'
+                'A connection could not be established to our servers to download the distribution index. No local copies were available to load. <br><br>The distribution index is an essential file which provides the latest server information. The launcher is unable to start without it. Ensure you are connected to the internet and relaunch the application. <br><br>It is very possible that the launcher has updated and changed the location for the distribution index file. If this is the case, it is recommended to install the latest version of the launcher from the releases page. <br><br>If you continue to have issues, please contact the developer of the launcher.',
+                'Download Latest Version',
+                'Close Launcher'
             )
             setOverlayHandler(() => {
                 const window = remote.getCurrentWindow()
                 window.close()
+                shell.openExternal('https://github.com/dscalzi/HeliosLauncher/releases')
             })
-            toggleOverlay(true)
+            toggleOverlay(true, true)
         })
     }, 750)
 }


### PR DESCRIPTION
Whilst having a look at possible solutions to a startup-loop when a user is using an old launcher version with an outdated distribution URL, I noticed that a json parse error was being thrown every time pullLocal was being attempted. I've gone ahead and caught the parse error so that we can reject the promise as intended, rather than letting the error cause the startup-loop.

Since it's now showing the intended invalid distribution index overlay, I've gone ahead and added a little more information to the error overlay, mentioning how the URL could be outdated and that a manual launcher update is recommended. Alongside this, there'll also be a button that takes them to the releases page to download from.

I hope this helps to at least eleviate any issues for users that are using outdated versions (unknowingly) that aren't aware there is a new release to update to (which updates the distro url). 

The red area shows the overlay changes:
![image](https://user-images.githubusercontent.com/25883284/90012508-67ef5080-dc9b-11ea-8682-c29e648dcb36.png)