### PR TITLE
Implementation for secret server codes for hidden servers

### DIFF
--- a/app/assets/css/launcher.css
+++ b/app/assets/css/launcher.css
@@ -1387,7 +1387,16 @@ input:checked + .toggleSwitchSlider:before {
     font-weight: bold;
 }
 
-.settingsServerCode:not([valid]) > .settingsServerCodeContent > .settingsServerCodeMainWrapper > .settingsServerCodeDetails > .settingsServerCodeServerName {
+.settingsServerCodeServerNamesContent {
+    max-width: 650px;
+}
+
+.settingsServerCodeServerName {
+    margin-right: 35px;
+    font-size: 14px;
+}
+
+.settingsServerCode:not([valid]) > .settingsServerCodeContent > .settingsServerCodeMainWrapper > .settingsServerCodeDetails > .settingsServerCodeServerNamesContent > .settingsServerCodeServerName {
     color: red;
 }
 

--- a/app/assets/css/launcher.css
+++ b/app/assets/css/launcher.css
@@ -1254,7 +1254,7 @@ input:checked + .toggleSwitchSlider:before {
     color: rgba(255, 255, 255, 0.75);
 }
 
-/* Description for the file selector. */
+/* Description for the File selectors. */
 .settingsFileSelDesc {
     font-size: 10px;
     margin: 20px 0px;
@@ -1262,6 +1262,51 @@ input:checked + .toggleSwitchSlider:before {
     width: 89%;
 }
 .settingsFileSelDesc strong {
+    font-family: 'Avenir Medium';
+}
+
+/* Main container for File selectors. */
+.settingsServerCodeContainer {
+    display: flex;
+    flex-direction: column;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.50);
+    margin-bottom: 20px;
+    margin-top: 20px;
+    width: 75%;
+}
+
+/* Server Code title. */
+.settingsServerCodeTitle {
+    margin-bottom: 10px;
+    font-size: 18px;
+    font-weight: bold;
+}
+
+/* Wrapper container for the actionable elements. */
+.settingsServerCodeActions {
+    display: flex;
+    width: 90%;
+}
+
+/* Enabled text field which stores the secret code if available. */
+.settingsServerCodeVal {
+    border-radius: 0px !important;
+    width: 100%;
+    padding: 5px 10px;
+    font-size: 12px;
+    height: 30px;
+}
+
+/* Description for the file selector. */
+.settingsServerCodeDesc {
+    margin: 20px 0px;
+    color: grey;
+    font-size: 14px;
+    width: 90%;
+}
+
+
+.settingsServerCodeDesc strong {
     font-family: 'Avenir Medium';
 }
 

--- a/app/assets/css/launcher.css
+++ b/app/assets/css/launcher.css
@@ -1279,26 +1279,46 @@ input:checked + .toggleSwitchSlider:before {
 .settingsServerCodeTitle {
     margin-bottom: 10px;
     font-size: 18px;
-    font-weight: bold;
+    font-family: 'Avenir Medium';
 }
 
 /* Wrapper container for the actionable elements. */
 .settingsServerCodeActions {
     display: flex;
-    width: 90%;
+    width: 60%;
 }
 
 /* Enabled text field which stores the secret code if available. */
-.settingsServerCodeVal {
+.settingsInputServerCodeVal {
     border-radius: 0px !important;
     width: 100%;
     padding: 5px 10px;
     font-size: 12px;
-    height: 30px;
+}
+
+.settingsInputServerCodeButton {
+    border: 0px;
+    border-radius: 3px 3px 3px 3px;
+    font-size: 12px;
+    padding: 0px 5px;
+    margin-left: 10px;
+    cursor: pointer;
+    background: rgba(126, 126, 126, 0.57);
+    transition: 0.25s ease;
+    white-space: nowrap;
+    outline: none;
+}
+.settingsInputServerCodeButton:hover,
+.settingInputServerCodeButton:focus {
+    text-shadow: 0px 0px 20px white;
+}
+.settingsInputServerCodeButton:active {
+    text-shadow: 0px 0px 20px rgba(255, 255, 255, 0.75);
+    color: rgba(255, 255, 255, 0.75);
 }
 
 /* Description for the file selector. */
-.settingsServerCodeDesc {
+.settingsServerCodesDesc {
     margin: 20px 0px;
     color: grey;
     font-size: 14px;
@@ -1306,8 +1326,91 @@ input:checked + .toggleSwitchSlider:before {
 }
 
 
-.settingsServerCodeDesc strong {
+.settingsServerCodesDesc strong {
     font-family: 'Avenir Medium';
+}
+
+#settingsServerCodesListContent {
+    font-size: 16px;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 3px;
+    color: white;
+    margin-top: 10px;
+}
+
+.settingsServerCode {
+    padding: 8px 0px 8px 8px;
+}
+
+/* Main content container for server code element information. */
+.settingsServerCodeContent {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    transition: opacity 0.25s ease;
+}
+
+/* Wrapper container for the left side of a server code element. */
+.settingsServerCodeMainWrapper {
+    display: flex;
+    align-items: center;
+}
+
+.settingsServerCodeRemoveWrapper {
+    margin-right: 25px;
+}
+
+/* Server code valid/invalid status. */
+.settingsServerCodeStatus {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background-color: #c32625;
+    margin-right: 15px;
+    transition: 0.25s ease;
+}
+
+.settingsServerCode[valid] > .settingsServerCodeContent > .settingsServerCodeMainWrapper > .settingsServerCodeStatus {
+    background-color: #4ddd19;
+}
+
+/* Mod details container. */
+.settingsServerCodeDetails {
+    display: flex;
+    flex-direction: column;
+}
+
+.settingsServerCodeName {
+    display: flex;
+    flex-direction: column;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.settingsServerCode:not([valid]) > .settingsServerCodeContent > .settingsServerCodeMainWrapper > .settingsServerCodeDetails > .settingsServerCodeServerName {
+    color: red;
+}
+
+/* Button to remove drop-in mods. */
+.settingsServerCodeRemoveButton {
+    background: none;
+    border: none;
+    font-size: 14px;
+    text-align: right;
+    padding: 0px;
+    color: grey;
+    cursor: pointer;
+    outline: none;
+    transition: 0.25s ease;
+    font-weight: bold;
+}
+
+.settingsServerCodeRemoveButton:hover,
+.settingsServerCodeRemoveButton:focus {
+    color: red;
+}
+.settingsServerCodeRemoveButton:active {
+    color: #9b1f1f;
 }
 
 /* * *
@@ -1577,15 +1680,14 @@ input:checked + .toggleSwitchSlider:before {
 
 /* Mod elements. */
 .settingsMod,
-.settingsDropinMod {
-    padding: 10px;
-}
 .settingsSubMod {
     padding: 10px 0px 10px 15px;
     margin-left: 20px;
     border-left: 1px solid rgba(255, 255, 255, 0.5);
 }
-
+.settingsDropinMod {
+    padding: 10px;
+}
 /* Main content container for mod element information. */
 .settingsModContent {
     display: flex;
@@ -1630,7 +1732,7 @@ input:checked + .toggleSwitchSlider:before {
 
 /* Set the status color of an enabled mod. */
 .settingsBaseMod[enabled] > .settingsModContent > .settingsModMainWrapper > .settingsModStatus {
-    background-color: rgb(165, 195, 37);
+    background-color: #4ddd19;
 }
 
 /* Add opacity to submods of a disabled mod. */

--- a/app/assets/css/launcher.css
+++ b/app/assets/css/launcher.css
@@ -1278,7 +1278,7 @@ input:checked + .toggleSwitchSlider:before {
 /* Server Code title. */
 .settingsServerCodeTitle {
     margin-bottom: 10px;
-    font-size: 18px;
+    font-size: 14px;
     font-family: 'Avenir Medium';
 }
 
@@ -1321,7 +1321,7 @@ input:checked + .toggleSwitchSlider:before {
 .settingsServerCodesDesc {
     margin: 20px 0px;
     color: grey;
-    font-size: 14px;
+    font-size: 10px;
     width: 90%;
 }
 
@@ -1331,7 +1331,7 @@ input:checked + .toggleSwitchSlider:before {
 }
 
 #settingsServerCodesListContent {
-    font-size: 16px;
+    font-size: 10px;
     background: rgba(0, 0, 0, 0.25);
     border-radius: 3px;
     color: white;
@@ -1383,7 +1383,7 @@ input:checked + .toggleSwitchSlider:before {
 .settingsServerCodeName {
     display: flex;
     flex-direction: column;
-    font-size: 16px;
+    font-size: 12px;
     font-weight: bold;
 }
 
@@ -1395,7 +1395,7 @@ input:checked + .toggleSwitchSlider:before {
 .settingsServerCodeRemoveButton {
     background: none;
     border: none;
-    font-size: 14px;
+    font-size: 12px;
     text-align: right;
     padding: 0px;
     color: grey;

--- a/app/assets/js/configmanager.js
+++ b/app/assets/js/configmanager.js
@@ -44,8 +44,8 @@ exports.setDataDirectory = function(dataDirectory){
  *
  * @returns {string} The server code that has been put into the launcher
  */
-exports.getServerCode = function(def = false){
-    return !def ? config.settings.launcher.serverCode : DEFAULT_CONFIG.settings.launcher.serverCode
+exports.getServerCode = function(){
+    return config.settings.launcher.serverCode
 }
 
 /**

--- a/app/assets/js/configmanager.js
+++ b/app/assets/js/configmanager.js
@@ -40,21 +40,21 @@ exports.setDataDirectory = function(dataDirectory){
 }
 
 /**
- * Get the launcher's server code if set. This will be used to load hidden servers.
+ * Get the launcher's available server codes. This will be used to load hidden servers.
  *
- * @returns {string} The server code that has been put into the launcher
+ * @returns {string[]} The server codes list that has been put into the launcher's configuration
  */
-exports.getServerCode = function(){
-    return config.settings.launcher.serverCode
+exports.getServerCodes = function(){
+    return config.settings.launcher.serverCodes
 }
 
 /**
  * Set the new server code
  *
- * @param {string} serverCode The new server code.
+ * @param {string[]} serverCodes The new server code list.
  */
-exports.setServerCode = function(serverCode){
-    config.settings.launcher.serverCode = serverCode
+exports.setServerCodes = function(serverCodes){
+    config.settings.launcher.serverCodes = serverCodes
 }
 
 const configPath = path.join(exports.getLauncherDirectory(), 'config.json')
@@ -110,7 +110,7 @@ const DEFAULT_CONFIG = {
         launcher: {
             allowPrerelease: false,
             dataDirectory: dataPath,
-            serverCode: null
+            serverCodes: []
         }
     },
     newsCache: {

--- a/app/assets/js/configmanager.js
+++ b/app/assets/js/configmanager.js
@@ -23,7 +23,7 @@ exports.getLauncherDirectory = function(){
 /**
  * Get the launcher's data directory. This is where all files related
  * to game launch are installed (common, instances, java, etc).
- * 
+ *
  * @returns {string} The absolute path of the launcher's data directory.
  */
 exports.getDataDirectory = function(def = false){
@@ -32,11 +32,29 @@ exports.getDataDirectory = function(def = false){
 
 /**
  * Set the new data directory.
- * 
+ *
  * @param {string} dataDirectory The new data directory.
  */
 exports.setDataDirectory = function(dataDirectory){
     config.settings.launcher.dataDirectory = dataDirectory
+}
+
+/**
+ * Get the launcher's server code if set. This will be used to load hidden servers.
+ *
+ * @returns {string} The server code that has been put into the launcher
+ */
+exports.getServerCode = function(def = false){
+    return !def ? config.settings.launcher.serverCode : DEFAULT_CONFIG.settings.launcher.serverCode
+}
+
+/**
+ * Set the new server code
+ *
+ * @param {string} serverCode The new server code.
+ */
+exports.setServerCode = function(serverCode){
+    config.settings.launcher.serverCode = serverCode
 }
 
 const configPath = path.join(exports.getLauncherDirectory(), 'config.json')
@@ -91,7 +109,8 @@ const DEFAULT_CONFIG = {
         },
         launcher: {
             allowPrerelease: false,
-            dataDirectory: dataPath
+            dataDirectory: dataPath,
+            serverCode: null
         }
     },
     newsCache: {

--- a/app/assets/js/distromanager.js
+++ b/app/assets/js/distromanager.js
@@ -512,15 +512,16 @@ class DistroIndex {
      *
      * @param {string} id The ID of the server.
      *
-     * @returns {Server} The server configuration with the given ID or null.
+     * @returns {Server[]} The server configuration with the given ID or null.
      */
-    getServerFromCode(code){
+    getServersFromCode(code){
+        let servs = []
         for(let serv of this.servers){
             if(serv.serverCode === code){
-                return serv
+                servs.push(serv)
             }
         }
-        return null
+        return servs
     }
 
     /**

--- a/app/assets/js/distromanager.js
+++ b/app/assets/js/distromanager.js
@@ -399,6 +399,13 @@ class Server {
     }
 
     /**
+     * @returns {string} The server code for this server
+     */
+    getServerCode(){
+        return this.serverCode
+    }
+
+    /**
      * @returns {boolean} Whether or not the server is autoconnect.
      * by default.
      */

--- a/app/assets/js/distromanager.js
+++ b/app/assets/js/distromanager.js
@@ -507,6 +507,23 @@ class DistroIndex {
     }
 
     /**
+     * Get a server configuration by its ID. If it does not
+     * exist, null will be returned.
+     *
+     * @param {string} id The ID of the server.
+     *
+     * @returns {Server} The server configuration with the given ID or null.
+     */
+    getServerFromCode(code){
+        for(let serv of this.servers){
+            if(serv.serverCode === code){
+                return serv
+            }
+        }
+        return null
+    }
+
+    /**
      * Get the main server.
      * 
      * @returns {Server} The main server.

--- a/app/assets/js/scripts/landing.js
+++ b/app/assets/js/scripts/landing.js
@@ -780,8 +780,10 @@ function checkCurrentServer(errorOverlay = true){
                             'Switch Server'
                         )
                         setOverlayHandler(() => {
-                            document.activeElement.blur()
                             toggleServerSelection(true)
+                        })
+                        setDismissHandler(() => {
+                            toggleOverlay(false)
                         })
                         toggleOverlay(true, true)
                     }

--- a/app/assets/js/scripts/landing.js
+++ b/app/assets/js/scripts/landing.js
@@ -85,7 +85,7 @@ function setLaunchEnabled(val){
 
 // Bind launch button
 document.getElementById('launch_button').addEventListener('click', function(e){
-    if(checkCurrentServer(false)){
+    if(checkCurrentServer(true)){
         loggerLanding.log('Launching game..')
         const mcVersion = DistroManager.getDistribution().getServer(ConfigManager.getSelectedServer()).getMinecraftVersion()
         const jExe = ConfigManager.getJavaExecutable()

--- a/app/assets/js/scripts/landing.js
+++ b/app/assets/js/scripts/landing.js
@@ -85,26 +85,28 @@ function setLaunchEnabled(val){
 
 // Bind launch button
 document.getElementById('launch_button').addEventListener('click', function(e){
-    loggerLanding.log('Launching game..')
-    const mcVersion = DistroManager.getDistribution().getServer(ConfigManager.getSelectedServer()).getMinecraftVersion()
-    const jExe = ConfigManager.getJavaExecutable()
-    if(jExe == null){
-        asyncSystemScan(mcVersion)
-    } else {
+    if(checkCurrentServer(false)){
+        loggerLanding.log('Launching game..')
+        const mcVersion = DistroManager.getDistribution().getServer(ConfigManager.getSelectedServer()).getMinecraftVersion()
+        const jExe = ConfigManager.getJavaExecutable()
+        if(jExe == null){
+            asyncSystemScan(mcVersion)
+        } else {
 
-        setLaunchDetails(Lang.queryJS('landing.launch.pleaseWait'))
-        toggleLaunchArea(true)
-        setLaunchPercentage(0, 100)
+            setLaunchDetails(Lang.queryJS('landing.launch.pleaseWait'))
+            toggleLaunchArea(true)
+            setLaunchPercentage(0, 100)
 
-        const jg = new JavaGuard(mcVersion)
-        jg._validateJavaBinary(jExe).then((v) => {
-            loggerLanding.log('Java version meta', v)
-            if(v.valid){
-                dlAsync()
-            } else {
-                asyncSystemScan(mcVersion)
-            }
-        })
+            const jg = new JavaGuard(mcVersion)
+            jg._validateJavaBinary(jExe).then((v) => {
+                loggerLanding.log('Java version meta', v)
+                if(v.valid){
+                    dlAsync()
+                } else {
+                    asyncSystemScan(mcVersion)
+                }
+            })
+        }
     }
 })
 
@@ -758,6 +760,37 @@ function dlAsync(login = true){
             }
         })
     })
+}
+
+/**
+ * Checks the current server to ensure that they still have permission to play it (checking server code, if applicable) and open up an error overlay if specified
+ * @Param {boolean} whether or not to show the error overlay
+ */
+function checkCurrentServer(errorOverlay = true){
+    const selectedServId = ConfigManager.getSelectedServer()
+    if(selectedServId){
+        const selectedServ = DistroManager.getDistribution().getServer(selectedServId)
+        if(selectedServ){
+            if(selectedServ.getServerCode() && selectedServ.getServerCode() !== ''){
+                if(!ConfigManager.getServerCodes().includes(selectedServ.getServerCode())){
+                    if(errorOverlay){
+                        setOverlayContent(
+                            'Current Server Restricted!',
+                            'It seems that you no longer have the server code required to access this server! Please switch to a different server to play on.<br><br>If you feel this is an error, please contact the server administrator',
+                            'Switch Server'
+                        )
+                        setOverlayHandler(() => {
+                            document.activeElement.blur()
+                            toggleServerSelection(true)
+                        })
+                        toggleOverlay(true, true)
+                    }
+                    return false
+                }
+            }
+        }
+        return true
+    }
 }
 
 /**

--- a/app/assets/js/scripts/overlay.js
+++ b/app/assets/js/scripts/overlay.js
@@ -267,6 +267,12 @@ function populateServerListings(){
     const servers = distro.getServers()
     let htmlString = ''
     for(const serv of servers){
+        if(serv.getServerCode() != null && serv.getServerCode() === ''){
+            if(ConfigManager.getServerCode() !== serv.getServerCode()){
+                // skips any servers which the player hasn't got the code to access
+                continue
+            }
+        }
         htmlString += `<button class="serverListing" servid="${serv.getID()}" ${serv.getID() === giaSel ? 'selected' : ''}>
             <img class="serverListingImg" src="${serv.getIcon()}"/>
             <div class="serverListingDetails">

--- a/app/assets/js/scripts/overlay.js
+++ b/app/assets/js/scripts/overlay.js
@@ -267,11 +267,8 @@ function populateServerListings(){
     const servers = distro.getServers()
     let htmlString = ''
     for(const serv of servers){
-        if(serv.getServerCode() != null && serv.getServerCode() === ''){
-            if(ConfigManager.getServerCode() !== serv.getServerCode()){
-                // skips any servers which the player hasn't got the code to access
-                continue
-            }
+        if(serv.getServerCode() && !ConfigManager.getServerCodes().includes(serv.getServerCode())){
+            continue
         }
         htmlString += `<button class="serverListing" servid="${serv.getID()}" ${serv.getID() === giaSel ? 'selected' : ''}>
             <img class="serverListingImg" src="${serv.getIcon()}"/>

--- a/app/assets/js/scripts/settings.js
+++ b/app/assets/js/scripts/settings.js
@@ -335,6 +335,7 @@ function bindServerCodeButtons(){
     document.getElementById('settingsAddServerCode').onclick = () => {
         for(let ele of document.getElementsByClassName('settingsInputServerCodeVal')){
             const code = ele.value
+            ele.value = ''
             if(!ConfigManager.getServerCodes().includes(code) && code){
                 ConfigManager.getServerCodes().push(code)
                 ConfigManager.save()

--- a/app/assets/js/scripts/settings.js
+++ b/app/assets/js/scripts/settings.js
@@ -136,6 +136,8 @@ function initSettingsValues(){
                         v.value = gFn()
                     } else if (cVal === 'DataDirectory'){
                         v.value = gFn()
+                    } else if (cVal === 'ServerCode'){
+                        v.value = gFn()
                     } else if(cVal === 'JVMOptions'){
                         v.value = gFn().join(' ')
                     } else {

--- a/app/assets/js/scripts/settings.js
+++ b/app/assets/js/scripts/settings.js
@@ -732,18 +732,21 @@ function resolveDropinModsForUI(){
 }
 
 function resolveServerCodesForUI(){
+    /* Server Codes */
     let servCodes = ''
     for(let servCode of ConfigManager.getServerCodes()){
-        const serv = DistroManager.getDistribution().getServerFromCode(servCode)
+        const servs = DistroManager.getDistribution().getServersFromCode(servCode)
+        const valid = servs && servs.length
         servCodes +=
             `
-                <div id="${servCode}" class="settingsServerCode" ${serv ? 'valid' : ''}>
+                <div id="${servCode}" class="settingsServerCode" ${valid ? 'valid' : ''}>
                     <div class="settingsServerCodeContent">
                         <div class="settingsServerCodeMainWrapper">
                             <div class="settingsServerCodeStatus"></div>
                             <div class="settingsServerCodeDetails">
                                 <span class="settingsServerCodeName">${servCode}</span>
-                                <span class="settingsServerCodeServerName"> ${serv ? serv.getName() : 'Invalid Code'}</span> 
+                                <div class="settingsServerCodeServerNamesContent" code="${servCode}">                      
+                                </div>
                             </div>
                         </div>
                         <div class="settingsServerCodeRemoveWrapper">
@@ -755,8 +758,32 @@ function resolveServerCodesForUI(){
     }
 
     document.getElementById('settingsServerCodesListContent').innerHTML = servCodes
-}
 
+    /* Server Names List */
+    for(let ele of document.getElementsByClassName('settingsServerCodeServerNamesContent')){
+        servNames = ''
+        const code = ele.getAttribute('code')
+        const servs = DistroManager.getDistribution().getServersFromCode(code)
+        const valid = servs && servs.length
+        loggerSettings.log('valid: ' + valid)
+        if(valid){
+            for(let serv of servs){
+                loggerSettings.log('server: ' + serv.getName())
+                servNames +=
+                    `
+                    <span class="settingsServerCodeServerName">${serv.getName()}</span> 
+                    `
+            }
+        } else {
+            servNames =
+                `
+                    <span class="settingsServerCodeServerName">Invalid Code</span> 
+                `
+        }
+
+        ele.innerHTML = servNames
+    }
+}
 /**
  * Bind the remove button for each loaded drop-in mod.
  */

--- a/app/settings.ejs
+++ b/app/settings.ejs
@@ -267,13 +267,16 @@
                 <div class="settingsFileSelDesc">All game files and local Java installations will be stored in the data directory.<br>Screenshots and world saves are stored in the instance folder for the corresponding server configuration.</div>
             </div>
             <div class="settingsServerCodeContainer">
-                <div class="settingsServerCodeTitle">Server Codes</div>
+                <div class="settingsServerCodeTitle">Your Server Codes</div>
                 <div class="settingsServerCodeContent">
                     <div class="settingsServerCodeActions">
-                        <input class="settingsServerCodeVal" type="text" value="" cValue="ServerCode">
+                        <input class="settingsInputServerCodeVal" type="text">
+                        <button class="settingsInputServerCodeButton" id="settingsAddServerCode">Add Code</button>
                     </div>
                 </div>
-                <div class="settingsServerCodeDesc">Allows you to access hidden servers that are set up to only show with the correct server code.</div>
+                <div id="settingsServerCodesListContent">
+                </div>
+                <div class="settingsServerCodesDesc">Setup your server codes to access hidden servers that are set up to only show with the correct server code.</div>
             </div>
         </div>
         <div id="settingsTabAbout" class="settingsTab" style="display: none;">

--- a/app/settings.ejs
+++ b/app/settings.ejs
@@ -267,13 +267,13 @@
                 <div class="settingsFileSelDesc">All game files and local Java installations will be stored in the data directory.<br>Screenshots and world saves are stored in the instance folder for the corresponding server configuration.</div>
             </div>
             <div class="settingsServerCodeContainer">
-                <div class="settingsServerCodeTitle">Server Code</div>
+                <div class="settingsServerCodeTitle">Server Codes</div>
                 <div class="settingsServerCodeContent">
                     <div class="settingsServerCodeActions">
                         <input class="settingsServerCodeVal" type="text" value="" cValue="ServerCode">
                     </div>
                 </div>
-                <div class="settingsServerCodeDesc">Any server code here (if valid) will grant you access to certain modpacks or servers that are set up to use the code.</div>
+                <div class="settingsServerCodeDesc">Allows you to access hidden servers that are set up to only show with the correct server code.</div>
             </div>
         </div>
         <div id="settingsTabAbout" class="settingsTab" style="display: none;">

--- a/app/settings.ejs
+++ b/app/settings.ejs
@@ -275,6 +275,7 @@
                     </div>
                 </div>
                 <div id="settingsServerCodesListContent">
+
                 </div>
                 <div class="settingsServerCodesDesc">Specify server codes here to grant access to hidden servers that wouldn't be available to all users by default.</div>
             </div>

--- a/app/settings.ejs
+++ b/app/settings.ejs
@@ -270,7 +270,7 @@
                 <div class="settingsServerCodeTitle">Server Code</div>
                 <div class="settingsServerCodeContent">
                     <div class="settingsServerCodeActions">
-                        <input class="settingsServerCodeVal" id="settingsJavaExecVal" type="text" value="" cValue="ServerCode">
+                        <input class="settingsServerCodeVal" type="text" value="" cValue="ServerCode">
                     </div>
                 </div>
                 <div class="settingsServerCodeDesc">Any server code here (if valid) will grant you access to certain modpacks or servers that are set up to use the code.</div>

--- a/app/settings.ejs
+++ b/app/settings.ejs
@@ -266,6 +266,15 @@
                 </div>
                 <div class="settingsFileSelDesc">All game files and local Java installations will be stored in the data directory.<br>Screenshots and world saves are stored in the instance folder for the corresponding server configuration.</div>
             </div>
+            <div class="settingsServerCodeContainer">
+                <div class="settingsServerCodeTitle">Server Code</div>
+                <div class="settingsServerCodeContent">
+                    <div class="settingsServerCodeActions">
+                        <input class="settingsServerCodeVal" id="settingsJavaExecVal" type="text" value="" cValue="ServerCode">
+                    </div>
+                </div>
+                <div class="settingsServerCodeDesc">Any server code here (if valid) will grant you access to certain modpacks or servers that are set up to use the code.</div>
+            </div>
         </div>
         <div id="settingsTabAbout" class="settingsTab" style="display: none;">
             <div class="settingsTabHeader">

--- a/app/settings.ejs
+++ b/app/settings.ejs
@@ -276,7 +276,7 @@
                 </div>
                 <div id="settingsServerCodesListContent">
                 </div>
-                <div class="settingsServerCodesDesc">Setup your server codes to access hidden servers that are set up to only show with the correct server code.</div>
+                <div class="settingsServerCodesDesc">Specify server codes here to grant access to hidden servers that wouldn't be available to all users by default.</div>
             </div>
         </div>
         <div id="settingsTabAbout" class="settingsTab" style="display: none;">

--- a/app/settings.ejs
+++ b/app/settings.ejs
@@ -270,7 +270,7 @@
                 <div class="settingsServerCodeTitle">Your Server Codes</div>
                 <div class="settingsServerCodeContent">
                     <div class="settingsServerCodeActions">
-                        <input class="settingsInputServerCodeVal" type="text">
+                        <input class="settingsInputServerCodeVal" placeholder="Enter Code" type="text">
                         <button class="settingsInputServerCodeButton" id="settingsAddServerCode">Add Code</button>
                     </div>
                 </div>

--- a/docs/distro.md
+++ b/docs/distro.md
@@ -143,6 +143,10 @@ Only one server in the array should have the `mainServer` property enabled. This
 
 Whether or not the server can be autoconnected to. If false, the server will not be autoconnected to even when the user has the autoconnect setting enabled.
 
+### `Server.serverCode: string`
+
+A code that allows you to privately distribute certain servers on the launcher. Players will only be able to see the server in their launcher if they have specified the code in the settings. If left blank, all players can see the server.
+
 ### `Server.modules: Module[]`
 
 An array of module objects.

--- a/docs/sample_distribution.json
+++ b/docs/sample_distribution.json
@@ -24,6 +24,7 @@
                 "largeImageKey": "server-prod"
             },
             "mainServer": true,
+            "serverCode": "",
             "autoconnect": true,
             "modules": [
                 {
@@ -438,6 +439,7 @@
                 "largeImageKey": "server-test"
             },
             "mainServer": false,
+            "serverCode": "",
             "autoconnect": true,
             "modules": [
                 {
@@ -852,6 +854,7 @@
                 "largeImageKey": "server-test"
             },
             "mainServer": false,
+            "serverCode": "",
             "autoconnect": true,
             "modules": [
                 {
@@ -1283,6 +1286,7 @@
                 "largeImageKey": "server-test"
             },
             "mainServer": false,
+            "serverCode": "",
             "autoconnect": false,
             "modules": [
                 {


### PR DESCRIPTION
> **Foreword:** The screenshots used here are from my own fork, purely due to things being easier to read because I've upscaled most elements in the launcher. The functionality is exactly the same, I took these commits straight from my personal build.

## What's This?
This is a new system that allows server administrators to attach a `serverCode` to each server in the `distribution.json` file.* When a code is attached to a server (as long as it's not empty), it will no longer show for all players on the launcher, and will only be available once your launcher has the correct 'server code' specified, similar to a password. Once you have a valid code in your launcher, the pack will show.

 *Nebula will need an update to be able to use a `serverCode` key inside of the servermeta.json

This is useful for communities that might want to have beta testers for a modpack/server, or a 'staff only' server, or maybe you have that special someone who you would like to play **RLCraft** with on your own private server.

## Okay, Go Ahead
Hey! I've been spending some time implementing this system, which was initially just a text box where you enter a code which will then be checked against with the other servers, but is now a dynamic styled list that allows you to add a number of server codes which can be removed at any time. 

In the `Launcher` section of your settings, you will now see a `Your Server Codes` section which will contain an empty field and a description, with an `Add Code` button beside it:  
![image](https://user-images.githubusercontent.com/25883284/90115013-6d0bd880-dd4b-11ea-822b-daabfd4da487.png)

**(Example)** If you have been given given access to a server for **MC Eternal** let's say, you can enter that code into the field and press `Add Code`, which will store the code as part of a configuration in your launcher and then display the list to you in the launcher. After this point, MC Eternal will now be available for you to navigate to inside of the server list:  
![image](https://user-images.githubusercontent.com/25883284/90115334-d7247d80-dd4b-11ea-9a97-b641709182ee.png)

You can remove your codes by pressing the `Remove` button on the opposite side of the list:
![image](https://user-images.githubusercontent.com/25883284/90115622-3edac880-dd4c-11ea-99d6-1bfaae8c1bc1.png)

From that screenshot, you can also see that you can easily identify between valid and invalid codes, due to the colour difference and the small coloured dot beside them. Valid server codes will also tell you which server they are valid for.

If your code becomes invalid because the server administrator has changed the code, you will will no longer be able to view that server in your server navigation overlay (because it no longer matches the code in the distribution.json)  
![image](https://user-images.githubusercontent.com/25883284/90115914-ad1f8b00-dd4c-11ea-9162-8ac94ac0f7c6.png)

**What about if the player played it last and it's already selected?**
If a player already had a server selected that they no longer have access for, there's no need to worry. Upon clicking play, the launcher will check all available codes to see if the player has permission for that particular server, and if they don't, they will be met with this error overlay, where they will be prompted to switch servers:  
![image](https://user-images.githubusercontent.com/25883284/90116215-156e6c80-dd4d-11ea-8341-62fb408fa3e3.png)

## Thanks
I hope this is a welcomed feature, and made use of since it seems pretty neat.
Thank you!
