### PR TITLE
Adding Nebula under developement section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ If you want to export the console output, simply right click anywhere on the con
 
 ---
 
+**Adding your own servers**
+If you want to use this for your own server, you need to use [Nebula](https://github.com/dscalzi/nebula).
+
+---
+
 **Build Installers**
 
 To build for your current platform.


### PR DESCRIPTION
As @TheFlash787 said on Discord, it would be interesting to put Nebula more prominently. This pull request allows you to add a link to Nebula in the developement section.