### PR TITLE
Test Mode

### DIFF
--- a/app/assets/js/configmanager.js
+++ b/app/assets/js/configmanager.js
@@ -103,7 +103,8 @@ const DEFAULT_CONFIG = {
     selectedServer: null, // Resolved
     selectedAccount: null,
     authenticationDatabase: {},
-    modConfigurations: []
+    modConfigurations: [],
+    testDistro: false
 }
 
 let config = null
@@ -158,6 +159,14 @@ exports.load = function(){
     logger.log('Successfully Loaded')
 }
 
+exports.setTesting = function(v){
+    config.testDistro = v ? true: false
+    exports.save()
+}
+
+exports.isTesting = function(){
+    return config.testDistro
+}
 /**
  * @returns {boolean} Whether or not the manager has been loaded.
  */

--- a/app/assets/js/distromanager.js
+++ b/app/assets/js/distromanager.js
@@ -538,9 +538,10 @@ exports.pullRemote = function(){
     }
     return new Promise((resolve, reject) => {
         const distroURL = 'http://mc.westeroscraft.com/WesterosCraftLauncher/distribution.json'
+        const testDistroURL = 'http://mc.westeroscraft.com/WesterosCraftLauncher/distribution.json'
         //const distroURL = 'https://gist.githubusercontent.com/dscalzi/53b1ba7a11d26a5c353f9d5ae484b71b/raw/'
         const opts = {
-            url: distroURL,
+            url: ConfigManager.isTesting()? testDistroURL : distroURL,
             timeout: 2500
         }
         const distroDest = path.join(ConfigManager.getLauncherDirectory(), 'distribution.json')


### PR DESCRIPTION
This PR adds a **test mode** to the Helios Launcher. 
If this is activated, not the default distribution is loaded, but another one (specified in the distromanager).
You can enable/disable the test mode via the console:
```javascript
ConfigManager.setTesting(true)
ConfigManager.setTesting(false)

ConfigManager.isTesting() // is in test mode
```

---

*DrDeee*