### PR TITLE
fix (DMG Build): arm64 files are corrupted

### DIFF
--- a/app/assets/js/scripts/uicore.js
+++ b/app/assets/js/scripts/uicore.js
@@ -50,7 +50,7 @@ if(!isDev){
                 loggerAutoUpdaterSuccess.log('New update available', info.version)
                 
                 if(process.platform === 'darwin'){
-                    info.darwindownload = `https://github.com/dscalzi/HeliosLauncher/releases/download/v${info.version}/Helios-Launcher-setup-${info.version}${process.arch === 'arm64' ? '-arm64' : '-x64'}.dmg`
+                    info.darwindownload = `https://github.com/dscalzi/HeliosLauncher/releases/download/v${info.version}/Helios-Launcher-setup.dmg`
                     showUpdateUI(info)
                 }
                 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -31,9 +31,8 @@ mac:
   target:
     - target: 'dmg'
       arch:
-        - 'x64'
-        - 'arm64'
-  artifactName: '${productName}-setup-${version}-${arch}.${ext}'
+        - 'universal'
+  artifactName: '${productName}-setup-${version}.${ext}'
   category: 'public.app-category.games'
 
 # Linux Configuration


### PR DESCRIPTION
According to Apple, arm64 binaries are corrupted and cannot be opened. This aims to fix the bug (which is a electron-builder bug btw)