### PR TITLE
(macOS ARM) Added aarch64 OpenJDK detect and install.

### DIFF
--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -904,7 +904,7 @@ class JavaGuard extends EventEmitter {
                 // If ARM JRE is not installed, AMD64 JRE still will run through Rosseta2
                 return amd64Path
             }
-            return pathArr.find(({ isARM }) => !isARM).execPath
+            return amd64Path
         } else {
             return null
         }

--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -858,7 +858,7 @@ class JavaGuard extends EventEmitter {
 
     /**
      * Attempts to find a valid x64 installation of Java on MacOS.
-     * If using Apple Silicon
+     * If using ARM arch tries to get ARM Java version first.
      * The system JVM directory is scanned for possible installations.
      * The JAVA_HOME enviroment variable and internet plugins directory
      * are also scanned and validated.
@@ -901,8 +901,7 @@ class JavaGuard extends EventEmitter {
             let armPath = pathArr.find(({ isARM }) => isARM).execPath
             if (process.arch.includes("arm")) { 
                 if (armPath) return armPath
-                // If ARM JRE is not installed, AMD64 JRE still will run through Rosseta2
-                return amd64Path
+                return null
             }
             return amd64Path
         } else {


### PR DESCRIPTION
On macOS with Apple Silicon processors ARM OpenJDK has ~100% perfomance boost over AMD64.
On the computer with ARM processor:
1. Added auto detecting installation of ARM type OpenJDK version first.
2. Changed Amazon Corretta url resolving to ARM (aarch64) OpenJDK https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.htmlaarc. 