### PR TITLE
(Apple Silicon) aarch64 OpenJDK detect and install

### DIFF
--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -152,7 +152,6 @@ class Util {
      * @param {string} desired The desired version.
      * @param {string} actual The actual version.
      */
-
     static mcVersionAtLeast(desired, actual){
         const des = desired.split('.')
         const act = actual.split('.')

--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -143,6 +143,9 @@ class DLTracker {
 
 class Util {
 
+
+    isARM64 = process.arch === "arm64";
+
     /**
      * Returns true if the actual version is greater than
      * or equal to the desired version.
@@ -150,6 +153,7 @@ class Util {
      * @param {string} desired The desired version.
      * @param {string} actual The actual version.
      */
+
     static mcVersionAtLeast(desired, actual){
         const des = desired.split('.')
         const act = actual.split('.')
@@ -302,7 +306,7 @@ class JavaGuard extends EventEmitter {
                 break
         }
 
-        const arch = process.arch.includes('arm') ? 'aarch64' : 'x64'
+        const arch = isARM64 ? 'aarch64' : 'x64'
         const url = `https://corretto.aws/downloads/latest/amazon-corretto-${major}-${arch}-${sanitizedOS}-jdk.${ext}`
 
         return new Promise((resolve, reject) => {
@@ -904,7 +908,7 @@ class JavaGuard extends EventEmitter {
             // TODO Revise this a bit, seems to work for now. Discovery logic should
             // probably just filter out the invalid architectures before it even
             // gets to this point.
-            if (process.arch.includes('arm')) {
+            if (isARM64) {
                 return pathArr.find(({ isARM }) => isARM)?.execPath ?? null
             } else {
                 return pathArr.find(({ isARM }) => !isARM)?.execPath ?? null

--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -305,7 +305,7 @@ class JavaGuard extends EventEmitter {
                 break
         }
 
-        const arch = this. ? 'aarch64' : 'x64'
+        const arch = isARM64 ? 'aarch64' : 'x64'
         const url = `https://corretto.aws/downloads/latest/amazon-corretto-${major}-${arch}-${sanitizedOS}-jdk.${ext}`
 
         return new Promise((resolve, reject) => {

--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -899,13 +899,13 @@ class JavaGuard extends EventEmitter {
         pathArr = JavaGuard._sortValidJavaArray(pathArr)
 
         if(pathArr.length > 0){
-            let amd64Path = pathArr.find(({ isARM }) => !isARM).execPath
-            let armPath = pathArr.find(({ isARM }) => isARM).execPath
+            let amd64 = pathArr.find(({ isARM }) => !isARM)
+            let arm = pathArr.find(({ isARM }) => isARM)
             if (process.arch.includes("arm")) { 
-                if (armPath) return armPath
+                if (arm) return arm.execPath
                 return null
             }
-            return amd64Path
+            return amd64.execPath
         } else {
             return null
         }

--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -18,7 +18,7 @@ const ConfigManager = require('./configmanager')
 const DistroManager = require('./distromanager')
 const isDev         = require('./isdev')
 
-const isARM64 = process.arch === "arm64";
+const isARM64 = process.arch === 'arm64';
 
 // Classes
 

--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -18,6 +18,8 @@ const ConfigManager = require('./configmanager')
 const DistroManager = require('./distromanager')
 const isDev         = require('./isdev')
 
+const isARM64 = process.arch === "arm64";
+
 // Classes
 
 /** Class representing a base asset. */
@@ -142,9 +144,6 @@ class DLTracker {
 }
 
 class Util {
-
-
-    isARM64 = process.arch === "arm64";
 
     /**
      * Returns true if the actual version is greater than
@@ -306,7 +305,7 @@ class JavaGuard extends EventEmitter {
                 break
         }
 
-        const arch = isARM64 ? 'aarch64' : 'x64'
+        const arch = this. ? 'aarch64' : 'x64'
         const url = `https://corretto.aws/downloads/latest/amazon-corretto-${major}-${arch}-${sanitizedOS}-jdk.${ext}`
 
         return new Promise((resolve, reject) => {

--- a/app/assets/js/assetguard.js
+++ b/app/assets/js/assetguard.js
@@ -302,7 +302,8 @@ class JavaGuard extends EventEmitter {
                 break
         }
 
-        const url = `https://corretto.aws/downloads/latest/amazon-corretto-${major}-${process.arch.includes("arm") ? "aarch64" : "x64"}-${sanitizedOS}-jdk.${ext}`
+        const arch = process.arch.includes('arm') ? 'aarch64' : 'x64'
+        const url = `https://corretto.aws/downloads/latest/amazon-corretto-${major}-${arch}-${sanitizedOS}-jdk.${ext}`
 
         return new Promise((resolve, reject) => {
             request.head({url, json: true}, (err, resp) => {
@@ -899,13 +900,16 @@ class JavaGuard extends EventEmitter {
         pathArr = JavaGuard._sortValidJavaArray(pathArr)
 
         if(pathArr.length > 0){
-            let amd64 = pathArr.find(({ isARM }) => !isARM)
-            let arm = pathArr.find(({ isARM }) => isARM)
-            if (process.arch.includes("arm")) { 
-                if (arm) return arm.execPath
-                return null
+
+            // TODO Revise this a bit, seems to work for now. Discovery logic should
+            // probably just filter out the invalid architectures before it even
+            // gets to this point.
+            if (process.arch.includes('arm')) {
+                return pathArr.find(({ isARM }) => isARM)?.execPath ?? null
+            } else {
+                return pathArr.find(({ isARM }) => !isARM)?.execPath ?? null
             }
-            return amd64.execPath
+
         } else {
             return null
         }


### PR DESCRIPTION
On macOS with Apple Silicon processors ARM OpenJDK has ~100% perfomance boost over AMD64.

On the computer with ARM processor:
1. Added auto detect installation path of ARM type OpenJDK and changed to ARM type detection only.
2. Changed Amazon Corretta url resolving from amd64 to aarch version