### PR TITLE
fix: invalid URL query decoding leads to code malformation in MSFT Auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,13 +145,11 @@ ipcMain.on(MSFT_OPCODE.OPEN_LOGIN, (ipcEvent, ...arguments_) => {
 
     msftAuthWindow.webContents.on('did-navigate', (_, uri) => {
         if (uri.startsWith(REDIRECT_URI_PREFIX)) {
-            let queries = uri.substring(REDIRECT_URI_PREFIX.length).split('#', 1).toString().split('&')
             let queryMap = {}
-
-            queries.forEach(query => {
-                const [name, value] = query.split('=')
-                queryMap[name] = decodeURI(value)
-            })
+            
+            new URL(uri).searchParams.forEach((v, k) => {
+                queryMap[k] = v;
+            });
 
             ipcEvent.reply(MSFT_OPCODE.REPLY_LOGIN, MSFT_REPLY_TYPE.SUCCESS, queryMap, msftAuthViewSuccess)
 


### PR DESCRIPTION
Hi,

This pull request fixes complains about Microsoft OAuth failing with a AADSTS70000 error code.
The error occurs seemlingly due to an invalid decoding of the redirect URL query, relying in the current code on a prefix removal, and a string split. 

This PR uses the correct URL API in Node.js and uses URL instance `searchParams#forEach` to populate the `queryMap`.