### PR TITLE
dx: add JSDoc generation command in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ Builds for macOS may not work on Windows/Linux and vice-versa.
 
 ---
 
+**Generate browsable JSDoc**
+
+```console
+> npm run jsdoc:generate
+```
+
+Useful to navigate quickly available functions in the UI's JS scripts.
+The generated docs will be available in `./docs/js/`.
+
+---
+
 ### Visual Studio Code
 
 All development of the launcher should be done using [Visual Studio Code][vscode].

--- a/index.js
+++ b/index.js
@@ -145,13 +145,11 @@ ipcMain.on(MSFT_OPCODE.OPEN_LOGIN, (ipcEvent, ...arguments_) => {
 
     msftAuthWindow.webContents.on('did-navigate', (_, uri) => {
         if (uri.startsWith(REDIRECT_URI_PREFIX)) {
-            let queries = uri.substring(REDIRECT_URI_PREFIX.length).split('#', 1).toString().split('&')
             let queryMap = {}
-
-            queries.forEach(query => {
-                const [name, value] = query.split('=')
-                queryMap[name] = decodeURI(value)
-            })
+            
+            new URL(uri).searchParams.forEach((v, k) => {
+                queryMap[k] = v;
+            });
 
             ipcEvent.reply(MSFT_OPCODE.REPLY_LOGIN, MSFT_REPLY_TYPE.SUCCESS, queryMap, msftAuthViewSuccess)
 

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,12 @@
+{
+  "source": {
+    "include": ["."],
+    "exclude": ["node_modules", "docs", "dist"],
+    "includePattern": ".+\\.js(doc|x)?$",
+    "excludePattern": "(^|\\/|\\\\)_"
+  },
+  "opts": {
+    "recurse": true,
+    "destination": "./docs/js/"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dist:win": "npm run dist -- -w",
     "dist:mac": "npm run dist -- -m",
     "dist:linux": "npm run dist -- -l",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "jsdoc:generate": "npx jsdoc -c jsdoc.json"
   },
   "engines": {
     "node": "22.x.x"
@@ -50,3 +51,4 @@
     "url": "git+https://github.com/dscalzi/HeliosLauncher.git"
   }
 }
+


### PR DESCRIPTION
Hi,

This pull request adds a new script in the `package.json` that can be useful for developer experience: `jsdoc:generate`.
This enhancement allows developers to quickly generate browsable HTML files for the JSDoc in docs/js/, using a preconfigured jsdoc.json config.

Not a critical PR, but a nice QoL.

(cc. @sjempotje for the idea)