### PR TITLE
fix: correct operator precedence in _resolveModuleLibraries

### DIFF
--- a/app/assets/js/processbuilder.js
+++ b/app/assets/js/processbuilder.js
@@ -866,7 +866,7 @@ class ProcessBuilder {
      * @returns {{[id: string]: string}} An object containing the paths of each library this module requires.
      */
     _resolveModuleLibraries(mdl){
-        if(!mdl.subModules.length > 0){
+        if(mdl.subModules.length === 0){
             return {}
         }
         let libs = {}


### PR DESCRIPTION
Fixed operator precedence bug in _resolveModuleLibraries function.

**Before:** `if(!mdl.subModules.length > 0)`
**After:** `if(mdl.subModules.length === 0)`

The original code had a bug due to JavaScript's operator precedence: the `!` operator binds tighter than `>`, so `!mdl.subModules.length` is evaluated first (producing a boolean), then `> 0` compares that boolean to 0, which is always truthy. The fix uses `=== 0` to correctly check if the array is empty.